### PR TITLE
Add head-metadata for markdown

### DIFF
--- a/metrics-models/niche-creation/README.md
+++ b/metrics-models/niche-creation/README.md
@@ -1,3 +1,12 @@
+---
+title: Niche Creation
+slug: /dimensions-define/niche-creation
+tags:
+  - Metrics Models
+  - Niche Creation
+description: The capacity to create and recognize meaningful diversity and thereby new capabilities.
+---
+
 # Niche Creation:
 Definition: The capacity to create and recognize meaningful diversity and thereby new capabilities.
 

--- a/metrics-models/niche-creation/ecological-diversity/developer-attraction.md
+++ b/metrics-models/niche-creation/ecological-diversity/developer-attraction.md
@@ -1,1 +1,17 @@
+---
+title: Developer Attraction
+slug: /metrics-models/niche-creation//developer-attraction
+tags:
+  - Metrics Models
+  - Niche Creation
+  - Developer Attraction
+description: Coming soon!
+---
+
 # Developer Attraction
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/niche-creation/ecological-diversity/organization-activity.md
+++ b/metrics-models/niche-creation/ecological-diversity/organization-activity.md
@@ -1,3 +1,13 @@
+---
+title: Organizations Activity
+slug: /metrics-models/niche-creation//developer-retention
+tags:
+  - Metrics Models
+  - Niche Creation
+  - Organizations Activity
+description: Describe how active organizations are in a community.
+---
+
 # Organizations Activity
 
 Organizational activity is used to describe how active organizations are in a community.

--- a/metrics-models/niche-creation/technological-advancement.md
+++ b/metrics-models/niche-creation/technological-advancement.md
@@ -1,1 +1,18 @@
+---
+title: Technological Advancement
+slug: /metrics-models/niche-creation//technological-advancement
+tags:
+  - Metrics Models
+  - Niche Creation
+  - Technological Advancement
+description: Coming soon!
+---
+
 # Technological Advancement
+
+:::tip
+
+Coming soon!
+
+:::
+

--- a/metrics-models/productivity/README.md
+++ b/metrics-models/productivity/README.md
@@ -1,3 +1,12 @@
+---
+title: Productivity
+slug: /dimensions-define/productivity
+tags:
+  - Metrics Models
+  - Productivity
+description: The efficiency with which an ecosystem or project converts inputs into output.
+---
+
 # Productivity
 Definition: The efficiency with which an ecosystem or project converts inputs into output.
 
@@ -39,4 +48,4 @@ Metrics Name | Definition | Threshold | Weight
 [Bug Issue Open Time](./community-service-and-support.md#bug_issue_open_time)  | Average/Median time (days) that bug issues have been opened for issues created in the last 90 days.|60|12.876%
 [PR Open Time](./community-service-and-support.md#pr_open_time) |Average/Median processing time (days) for new change requests created in the last 90 days, including closed/accepted change requests and unresolved change requests.|30|12.876%
 [Comment Frequency](./community-service-and-support.md#comment-frequency) |Determine the average number of comments per issue created in the last 90 days.|5|10.217%
-[Code Review　Count](./community-service-and-support.md#code-review-count) |Determine the average number of review comments per pull request created in the last 90 days|8| 10.217%
+[Code Review Count](./community-service-and-support.md#code-review-count) |Determine the average number of review comments per pull request created in the last 90 days|8| 10.217%

--- a/metrics-models/productivity/code/code-compliance-guarantee.md
+++ b/metrics-models/productivity/code/code-compliance-guarantee.md
@@ -1,1 +1,17 @@
+---
+title: Code Compliance Guarantee
+slug: /metrics-models/productivity/code-compliance-guarantee
+tags:
+  - Metrics Models
+  - Productivity
+  - Code Compliance Guarantee
+description: Coming soon!
+---
+
 # Code Compliance Guarantee
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/productivity/code/code-quality-guarantee.md
+++ b/metrics-models/productivity/code/code-quality-guarantee.md
@@ -1,3 +1,13 @@
+---
+title: Code Quality Guarantee
+slug: /metrics-models/productivity/code-quality-guarantee
+tags:
+  - Metrics Models
+  - Productivity
+  - Code Quality Guarantee
+description: The measurement of how to guarantee software quality using multiple proxies
+---
+
 # Code Quality Guarantee 
 
 Code, as the final output of a project, is the essence of the entire community's contribution. Code quality guarantee is the measurement of how to guarantee software quality using multiple proxies.

--- a/metrics-models/productivity/code/code-security-guarantee.md
+++ b/metrics-models/productivity/code/code-security-guarantee.md
@@ -1,1 +1,17 @@
+---
+title: Code Security Guarantee
+slug: /metrics-models/productivity/code-security-guarantee
+tags:
+  - Metrics Models
+  - Productivity
+  - Code Security Guarantee
+description: Coming soon!
+---
+
 # Code Security Guarantee
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/productivity/community-service-and-support.md
+++ b/metrics-models/productivity/community-service-and-support.md
@@ -1,3 +1,13 @@
+---
+title: Community Service and Support
+slug: /metrics-models/productivity/niche-creation
+tags:
+  - Metrics Models
+  - Productivity
+  - Community Service and Support
+description: Community Service and Support measures the quality of services and support provided by the community as directly perceived by a developer during the contribution process.
+---
+
 # Community Service and Support
 
 Community Service and Support measures the quality of services and support provided by the community as directly perceived by a developer during the contribution process.
@@ -36,11 +46,13 @@ Community Service and Support measures the quality of services and support provi
 * Threshold: 30 days
 
 ## Comment Frequency
+
 * Definition: Determine the average number of comments per issue created in the last 90 days.
 * Weight: 10.217%
 * Threshold: 5
 
 ## Code Review Count
+
 * Definition: Determine the average number of review comments per pull request created in the last 90 days.
 * Weight: 10.217%
 * Threshold: 8 
@@ -52,6 +64,7 @@ Community Service and Support measures the quality of services and support provi
 We use [AHP](https://en.wikipedia.org/wiki/Analytic_hierarchy_process) to calculate weight of each metric.
 
 ### AHP Input Data
+
 Metric Name | Updated Issues Count | Close PR Count | Issue First Response | Bug Issue Open Time | PR Open Time | Comment Frequency | Code Review Count
 --- | --- | --- | --- | --- | --- | --- | --- 
 Updated Issues Count|    1.000 | 1.000 | 1.333 | 1.500 | 1.500 | 2.000 | 2.000
@@ -89,7 +102,9 @@ The threshold we chose is based on the big-data observations from different type
 * [CHAOSS Metric Model: Community Service and Support](https://github.com/chaoss/wg-metrics-models/tree/main/metrics-model-libs/community-service-and-support)
 
 # Contributors
+
 ## Frontend
+
 * Shengxiang Zhang
 * Feng Zhong
 * Chaoqun Huang
@@ -97,6 +112,7 @@ The threshold we chose is based on the big-data observations from different type
 * Xingyou Lai
 
 ## Backend
+
 * Yehui Wang
 * Chenqi Shan
 * Shengbao Li

--- a/metrics-models/productivity/content.md
+++ b/metrics-models/productivity/content.md
@@ -1,1 +1,17 @@
+---
+title: Content
+slug: /metrics-models/productivity/content
+tags:
+  - Metrics Models
+  - Productivity
+  - Content
+description: Coming soon!
+---
+
 # Content
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/robustness/README.md
+++ b/metrics-models/robustness/README.md
@@ -1,3 +1,12 @@
+---
+title: Robustness
+slug: /dimensions-define/robustness
+tags:
+  - Metrics Models
+  - Robustness
+description: The capability of an ecosystem or project to face and survive disruptions.Determine
+---
+
 # Robustness
 Definition: The capability of an ecosystem or project to face and survive disruptions.Determine
 
@@ -13,12 +22,12 @@ Metrics Name | Definition | Threshold | Weight
 [Org Count](./activity.md#organization-count)  | Number of organizations to which active code contributors belong in the past 90 days. |10|11.501%
 [Created Since](./activity.md#created-since) |Determine how long a repository has existed since it was created (in months).|120|7.768%
 [Comment Frequency](./activity.md#comment-frequency) |Determine the average number of comments per issue created in the last 90 days.|5|7.768%
-[Code Review　Count](./activity.md#code-review-count) |Determine the average number of review comments per pull request created in the last 90 days|8| 4.919%
-[Updated Issues　Count](./activity.md#updated-issues-count) |Determine the number of issues updated in the last 90 days.|2500|4.919%
-[Recent Releases　Count](./activity.md#recent-releases-count)|Determine the number of releases in the last year.|12| 3.177%
-[Maintainer　Count](./activity.md#maintainer-count) | Determine the average number of maintainers per repository.|100|2.090%
-[Meeting　Count](./activity.md#meeting-count) | Determine the number of meetings held in the last 90 days.| 100| 2.090%
-[Meeting Attendee　Count](./activity.md#meeting-attendee-count) | Determine the average number of attendees per meeting in the last 90 days.|10| 2.090%
+[Code Review Count](./activity.md#code-review-count) |Determine the average number of review comments per pull request created in the last 90 days|8| 4.919%
+[Updated Issues Count](./activity.md#updated-issues-count) |Determine the number of issues updated in the last 90 days.|2500|4.919%
+[Recent Releases Count](./activity.md#recent-releases-count)|Determine the number of releases in the last year.|12| 3.177%
+[Maintainer Count](./activity.md#maintainer-count) | Determine the average number of maintainers per repository.|100|2.090%
+[Meeting Count](./activity.md#meeting-count) | Determine the number of meetings held in the last 90 days.| 100| 2.090%
+[Meeting Attendee Count](./activity.md#meeting-attendee-count) | Determine the average number of attendees per meeting in the last 90 days.|10| 2.090%
 
 ## [Developer Convertion](./developer/developer-convertion.md#developer-convertion)
 

--- a/metrics-models/robustness/activity.md
+++ b/metrics-models/robustness/activity.md
@@ -1,3 +1,13 @@
+---
+title: Activity
+slug: /metrics-models/robustness/activity
+tags:
+  - Metrics Models
+  - Robustness
+  - Activity
+description: Describe how active an open source community is.
+---
+
 # Activity
 
 Community Activity is used to describe how active an open source community is.
@@ -86,7 +96,7 @@ In order for an open source project to be sustainable, it must continue to be ma
 We use [AHP](https://en.wikipedia.org/wiki/Analytic_hierarchy_process) to calculate weight of each metric.
 
 ### AHP Input Data
-Metric Name | Contributor Count | Commit frequency | Updated Since | Org Count | Created Since | Comment Frequency | Code Review　Count | Closed Issues　Count | Updated Issues　Count | Recent Releases　Count | Maintainer　Count | Meeting　Count | Meeting Attendee　Count 
+Metric Name | Contributor Count | Commit frequency | Updated Since | Org Count | Created Since | Comment Frequency | Code Review Count | Closed Issues Count | Updated Issues Count | Recent Releases Count | Maintainer Count | Meeting Count | Meeting Attendee Count 
 --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
 Contributor Count | 1 | 1 | 2 | 2 | 3 | 3 | 4 | 4 | 4 | 5 | 6 | 6 | 6
 Commit frequency  | 1 | 1 | 2 | 2 | 3 | 3 | 4 | 4 | 4 | 5 | 6 | 6 | 6
@@ -94,13 +104,13 @@ Updated Since  | 0.5 | 0.5 | 1 | 2 | 2 | 2 | 3 | 3 | 3 | 4 | 5 | 5 | 5
 Org Count | 0.5 | 0.5 | 0.5 | 1 | 2 | 2 | 3 | 3 | 3 | 4 | 5 | 5 | 5
 Created Since | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 2 | 2 | 2 | 3 | 4 | 4 | 4
 Comment Frequency | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 2 | 2 | 2 | 3 | 4 | 4 | 4
-Code Review　Count | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
-~~Closed Issues　Count~~ | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
-Updated Issues　Count | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
-Recent Releases　Count | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 0.5 | 1 | 2 | 2 | 2
-Maintainer　Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
-Meeting　Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
-Meeting Attendee　Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
+Code Review Count | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
+~~Closed Issues Count~~ | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
+Updated Issues Count | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 1 | 1 | 1 | 2 | 3 | 3 | 3
+Recent Releases Count | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.5 | 0.5 | 0.5 | 1 | 2 | 2 | 2
+Maintainer Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
+Meeting Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
+Meeting Attendee Count | 0.167 | 0.167 | 0.2 | 0.2 | 0.25 | 0.25 | 0.333 | 0.333 | 0.333 | 0.5 | 1 | 1 | 1
 
 ### AHP Analysis Result
 
@@ -112,13 +122,13 @@ Updated Since | 1.657 | 12.742%
 Org Count  | 1.495 | 11.501%
 Created Since | 1.010 | 7.768%
 Comment Frequency | 1.010 | 7.768%
-Code Review　Count | 0.639 | 4.919%
-~~Closed Issues　Count~~| 0.639 | 4.919%
-Updated Issues　Count | 0.639 | 4.919%
-Recent Releases　Count| 0.413 | 3.177%
-Maintainer　Count | 0.272 | 2.090%
-Meeting　Count | 0.272 | 2.090%
-Meeting Attendee　Count | 0.272 | 2.090%
+Code Review Count | 0.639 | 4.919%
+~~Closed Issues Count~~| 0.639 | 4.919%
+Updated Issues Count | 0.639 | 4.919%
+Recent Releases Count| 0.413 | 3.177%
+Maintainer Count | 0.272 | 2.090%
+Meeting Count | 0.272 | 2.090%
+Meeting Attendee Count | 0.272 | 2.090%
 
 ### Consistency Test Results
 

--- a/metrics-models/robustness/developer/developer-convertion.md
+++ b/metrics-models/robustness/developer/developer-convertion.md
@@ -1,1 +1,17 @@
+---
+title: Developer Convertion
+slug: /metrics-models/robustness/developer-convertion
+tags:
+  - Metrics Models
+  - Robustness
+  - Developer Convertion
+description: Coming soon!
+---
+
 # Developer Convertion
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/robustness/developer/developer-retention.md
+++ b/metrics-models/robustness/developer/developer-retention.md
@@ -1,1 +1,17 @@
+---
+title: Developer Retention
+slug: /metrics-models/robustness/developer-retention
+tags:
+  - Metrics Models
+  - Robustness
+  - Developer Retention
+description: Coming soon!
+---
+
 # Developer Retention
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/robustness/organization/innner-connectedness.md
+++ b/metrics-models/robustness/organization/innner-connectedness.md
@@ -1,1 +1,17 @@
+---
+title: Inner Connectedness
+slug: /metrics-models/robustness/inner-connectedness
+tags:
+  - Metrics Models
+  - Robustness
+  - Inner Connectedness
+description: Coming soon!
+---
+
 # Inner Connectedness
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/robustness/organization/organization-collaboration-relationships.md
+++ b/metrics-models/robustness/organization/organization-collaboration-relationships.md
@@ -1,1 +1,17 @@
+---
+title: Organization Collaboration Relationships
+slug: /metrics-models/robustness/organization-collaboration-relationships
+tags:
+  - Metrics Models
+  - Robustness
+  - Organization Collaboration Relationships
+description: Coming soon!
+---
+
 # Organization Collaboration Relationships
+
+:::tip
+
+Coming soon!
+
+:::

--- a/metrics-models/robustness/organization/outbound-connectedness.md
+++ b/metrics-models/robustness/organization/outbound-connectedness.md
@@ -1,1 +1,17 @@
+---
+title: Outbound Connectedness
+slug: /metrics-models/robustness/outbound-connectedness
+tags:
+  - Metrics Models
+  - Robustness
+  - Outbound Connectedness
+description: Coming soon!
+---
+
 # Outbound Connectedness
+
+:::tip
+
+Coming soon!
+
+:::

--- a/user-guide/README.md
+++ b/user-guide/README.md
@@ -1,1 +1,15 @@
+---
+title: OSS Compass User Guide 
+slug: /user-guide 
+tags:
+  - User Guide
+description: Coming soon!
+---
+
 # OSS Compass User Guide 
+
+:::tip
+
+Coming soon!
+
+:::


### PR DESCRIPTION
## What did this Pull Request change?

Added head-matedata for all documents.  The head-matedata reference format is as follows

```markdown
---
title: Code Compliance Guarantee
slug: /metrics-models/productivity/code-compliance-guarantee
tags:
  - Metrics Models
  - Productivity
  - Code Compliance Guarantee
description: Coming soon!
---
```